### PR TITLE
Исправление некорректного форматирования

### DIFF
--- a/server/src/format.ts
+++ b/server/src/format.ts
@@ -36,9 +36,11 @@ export function FormatCode(text: string, tabSize: number = 4): string {
         trimmedLine = replaceKWords(trimmedLine);
 
         // Добавляем пробелы вокруг ключевых слов и операторов
-        trimmedLine = trimmedLine.replace(/(And|Or|\==|\!=|\<=|\>=|\>|\<)/g, ' $1 ');
+        trimmedLine = trimmedLine.replace(/\b(And|Or)\b/g, ' $1 ');
+        trimmedLine = trimmedLine.replace(/(==|!=|<=|>=|>|<)/g, ' $1 ');
 
-        trimmedLine = trimmedLine.replace(/(If|While|For|\;)/g, '$1 ');
+
+        trimmedLine = trimmedLine.replace(/\b(If|While|For|\;)\b/g, '$1 ');
 
         trimmedLine = trimmedLine.replace(/\s+/g, ' ');
 
@@ -129,62 +131,70 @@ function extractWordsBeforeComment(input: string): string[] {
 }
 
 function replaceKWords(param: string): string {
+    // словарь ключевых слов
+    const keywordMap: Record<string, string> = {
+        "import": "Import",
+        "private": "Private",
+        "macro": "MACRO",
+        "private macro": "PRIVATE MACRO",
+        "and": "And",
+        "begaction": "BegAction",
+        "break": "Break",
+        "codefor": "CodeFor",
+        "const": "Const",
+        "continue": "Continue",
+        "clearrecord": "ClearRecord",
+        "callr2m": "CallR2M",
+        "debugbreak": "DebugBreak",
+        "dttmsplit": "DtTmSplit",
+        "datetime": "DateTime",
+        "datesplit": "DateSplit",
+        "date": "Date",
+        "dateshift": "DateShift",
+        "endaction": "EndAction",
+        "elif": "ElIf",
+        "else": "Else",
+        "end": "End",
+        "exit": "Exit",
+        "false": "False",
+        "if": "If",
+        "integer": "Integer",
+        "int": "Int",
+        "message": "Message",
+        "msgbox": "MsgBox",
+        "null": "Null",
+        "not": "Not",
+        "or": "Or",
+        "println": "PrintLn",
+        "record": "Record",
+        "return": "Return",
+        "strlen": "StrLen",
+        "strbrk": "StrBrk",
+        "substr": "SubStr",
+        "string": "String",
+        "strset": "StrSet",
+        "strupr": "StrUpr",
+        "strlwr": "StrLwr",
+        "strfor": "StrFor",
+        "strsubst": "StrSubst",
+        "setparm": "SetParm",
+        "trim": "Trim",
+        "tooem": "ToOEM",
+        "true": "True",
+        "toansi": "ToANSI",
+        "timesplit": "TimeSplit",
+        "time": "Time",
+        "var": "Var",
+        "valtype": "ValType",
+        "while": "While"
+    };
 
-    param = param.replace("import", "Import");
-    param = param.replace("private", "Private");
-    param = param.replace("macro", "MACRO");
-    param = param.replace("Private MACRO", "PRIVATE MACRO");
-
-    param = param.replace("and", "And");
-    param = param.replace("begaction", "BegAction");
-    param = param.replace("break", "Break");
-    param = param.replace("codefor", "CodeFor");
-    param = param.replace("const", "Const");
-    param = param.replace("continue", "Continue");
-    param = param.replace("clearrecord", "ClearRecord");
-    param = param.replace("callr2m", "CallR2M");
-    param = param.replace("debugbreak", "DebugBreak");
-    param = param.replace("dttmsplit", "DtTmSplit");
-    param = param.replace("datetime", "DateTime");
-    param = param.replace("datesplit", "DateSplit");
-    param = param.replace("date", "Date");
-    param = param.replace("dateshift", "DateShift");
-    param = param.replace("endaction", "EndAction");
-    param = param.replace("elif", "ElIf");
-    param = param.replace("else", "Else");
-    param = param.replace("end", "End");
-    param = param.replace("exit", "Exit");
-    param = param.replace("false", "False");
-    param = param.replace("if", "If");
-    param = param.replace("integer", "Integer");
-    param = param.replace("int", "Int");
-    param = param.replace("message", "Message");
-    param = param.replace("msgbox", "MsgBox");
-    param = param.replace("null", "Null");
-    param = param.replace("not", "Not");
-    param = param.replace("or", "Or");
-    param = param.replace("println", "PrintLn");
-    param = param.replace("record", "Record");
-    param = param.replace("return", "Return");
-    param = param.replace("strlen", "StrLen");
-    param = param.replace("strbrk", "StrBrk");
-    param = param.replace("substr", "SubStr");
-    param = param.replace("string", "String");
-    param = param.replace("strset", "StrSet");
-    param = param.replace("strupr", "StrUpr");
-    param = param.replace("strlwr", "StrLwr");
-    param = param.replace("strfor", "StrFor");
-    param = param.replace("strsubst", "StrSubst");
-    param = param.replace("setparm", "SetParm");
-    param = param.replace("trim", "Trim");
-    param = param.replace("tooem", "ToOEM");
-    param = param.replace("true", "True");
-    param = param.replace("toansi", "ToANSI");
-    param = param.replace("timesplit", "TimeSplit");
-    param = param.replace("time", "Time");
-    param = param.replace("var", "Var");
-    param = param.replace("valtype", "ValType");
-    param = param.replace("while", "While");
-
-    return param;
+    // разбиваем строку на токены: слова, кавычки, операторы и пробелы
+    return param.replace(/\w+|\S/g, (token) => {
+        const lower = token.toLowerCase();
+        if (keywordMap[lower]) {
+            return keywordMap[lower];
+        }
+        return token;
+    });
 }


### PR DESCRIPTION
В оригинальном форматтере присутствуют ошибки. Например "Or" содержащаяся в имени переменной или поля выделялось как ключевое слово Or и разбивалось соответственно.